### PR TITLE
Parameter values for k and c must be numbers, not strings.

### DIFF
--- a/clustering/run_spectral.py
+++ b/clustering/run_spectral.py
@@ -36,4 +36,4 @@ parser.add_argument(
 	default=30
 )
 options = parser.parse_args()
-spectral(options.tweets,options.npmi,options.vdict,options.k,options.c)
+spectral(options.tweets,options.npmi,options.vdict,int(options.k),int(options.c))


### PR DESCRIPTION
run.sh passes the `k` parameter to `run_spectral.py`, which meant it was coming through as a string rather than a number, causing

```
File "/Users/ian/work/trendminer-python/clustering/knnmatrix.py", line 6, in knnmatrix
  indi=zeros(k*n,dtype=int); 
ValueError: sequence too large; must be smaller than 32
```
